### PR TITLE
Add cBioPortal setup configurations for multiple environments

### DIFF
--- a/cbioportal-setup/README.md
+++ b/cbioportal-setup/README.md
@@ -1,0 +1,57 @@
+# cBioPortal Setup
+
+This repository contains configuration and setup files for running cBioPortal in different environments. It provides three different setup options:
+
+## Setup Options
+
+1. [Docker Setup](docker/README.md)
+   - Containerized setup using Docker and Docker Compose
+   - Easiest to get started with
+   - Ideal for development and testing
+
+2. [Windows Setup](windows/README.md)
+   - Native Windows installation
+   - Direct installation on Windows without containers
+   - Good for Windows-based production environments
+
+3. [Linux Setup](linux/README.md)
+   - Native Linux installation
+   - Includes automated installation scripts
+   - Recommended for production deployments
+
+## Common Features
+
+All setups include:
+- SQL Server database integration
+- Complete configuration files
+- Logging setup
+- Study data management
+
+## Prerequisites
+
+- SQL Server instance
+- Java 11 or later (for non-Docker setups)
+- Docker Desktop (for Docker setup)
+- Git
+
+## Getting Started
+
+1. Choose your preferred setup option from the directories above
+2. Follow the README instructions in the respective directory
+3. Configure your database connection settings
+4. Start cBioPortal using the provided scripts
+
+## Database Configuration
+
+All setups require a SQL Server database. Update the following settings in your chosen setup's `portal.properties`:
+
+```properties
+db.user=your_username
+db.password=your_password
+db.host=your_database_host
+db.portal_db_name=cbioportal
+```
+
+## Contributing
+
+Feel free to submit issues and enhancement requests!

--- a/cbioportal-setup/docker/README.md
+++ b/cbioportal-setup/docker/README.md
@@ -1,0 +1,49 @@
+# Local cBioPortal Instance
+
+This directory contains the configuration for running a local instance of cBioPortal connected to your SQL Server database.
+
+## Prerequisites
+
+1. Docker Desktop installed and running
+2. SQL Server running with the following configuration:
+   - Host: localhost (will be accessed as host.docker.internal from Docker)
+   - Port: 1433
+   - Database: cbioportal (will be created by the migration)
+   - Authentication: SQL Server authentication enabled
+
+## Setup Instructions
+
+1. Update the database credentials in both files:
+   - `docker-compose.yml`
+   - `config/portal.properties`
+   Replace the following placeholders with your actual SQL Server credentials:
+   - `DB_USER=sa` (replace 'sa' with your username)
+   - `DB_PASSWORD=YourPassword` (replace 'YourPassword' with your actual password)
+
+2. Create the cBioPortal database in SQL Server:
+   ```sql
+   CREATE DATABASE cbioportal;
+   ```
+
+3. Start the cBioPortal services:
+   ```bash
+   docker-compose up -d
+   ```
+
+4. Access cBioPortal at: http://localhost:8080
+
+## Loading Studies
+
+Place your study files in the `study` directory. The files should follow the [cBioPortal study format](https://docs.cbioportal.org/file-formats/).
+
+## Troubleshooting
+
+1. If you encounter database connection issues:
+   - Verify SQL Server is running and accessible
+   - Check that the credentials in configuration files are correct
+   - Ensure SQL Server is configured to accept TCP/IP connections
+
+2. For other issues, check the logs:
+   ```bash
+   docker-compose logs -f
+   ```

--- a/cbioportal-setup/docker/config/portal.properties
+++ b/cbioportal-setup/docker/config/portal.properties
@@ -1,0 +1,24 @@
+db.host=host.docker.internal
+db.portal_db_name=cbioportal
+db.driver=com.microsoft.sqlserver.jdbc.SQLServerDriver
+db.connection_string=jdbc:sqlserver://host.docker.internal:1433;databaseName=cbioportal;encrypt=true;trustServerCertificate=true
+db.user=sa
+db.password=YourPassword
+
+# Authentication
+authenticate=false
+filter_groups_by_appname=false
+
+# Connection pool
+db.tomcat_resource_name=jdbc/cbioportal
+db.max_pool_size=50
+db.min_pool_size=2
+
+# Cache settings
+cache.enabled=true
+
+# Study paths
+cancer_study_path=/study/
+
+# Logging
+log.level=INFO

--- a/cbioportal-setup/docker/docker-compose.yml
+++ b/cbioportal-setup/docker/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+
+services:
+  cbioportal:
+    image: cbioportal/cbioportal:5.4.6
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    environment:
+      - DB_HOST=host.docker.internal
+      - DB_USER=sa  # Replace with your SQL Server username
+      - DB_PASSWORD=YourPassword  # Replace with your SQL Server password
+      - DB_CONNECTION_STRING=jdbc:sqlserver://host.docker.internal:1433;databaseName=cbioportal;encrypt=true;trustServerCertificate=true
+    volumes:
+      - ./study:/study/
+      - ./config/portal.properties:/local/portal.properties
+    depends_on:
+      - migration
+
+  migration:
+    image: cbioportal/cbioportal:5.4.6
+    restart: "no"
+    environment:
+      - DB_HOST=host.docker.internal
+      - DB_USER=sa  # Replace with your SQL Server username
+      - DB_PASSWORD=YourPassword  # Replace with your SQL Server password
+      - DB_CONNECTION_STRING=jdbc:sqlserver://host.docker.internal:1433;databaseName=cbioportal;encrypt=true;trustServerCertificate=true
+    command: [ "/wait-for-it.sh", "host.docker.internal:1433", "--", "python3", "/cbioportal/core/src/main/scripts/migrate_db.py", "--properties-file", "/cbioportal/portal.properties" ]

--- a/cbioportal-setup/linux/README.md
+++ b/cbioportal-setup/linux/README.md
@@ -1,0 +1,112 @@
+# Linux cBioPortal Installation
+
+This guide provides instructions for installing cBioPortal directly on a Linux system.
+
+## Prerequisites
+
+- Ubuntu/Debian-based Linux distribution (for other distributions, modify the package installation commands accordingly)
+- Root access or sudo privileges
+- SQL Server instance accessible from the Linux machine
+
+## Directory Structure
+
+```
+/opt/cbioportal/
+├── cbioportal/        # Source code
+├── config/            # Configuration files
+│   ├── portal.properties
+│   └── log4j.properties
+├── studies/           # Study files
+└── logs/             # Application logs
+```
+
+## Installation
+
+1. Clone this repository and navigate to it:
+```bash
+git clone <repository-url>
+cd cbioportal-linux
+```
+
+2. Make the scripts executable:
+```bash
+chmod +x install.sh start.sh
+```
+
+3. Run the installation script:
+```bash
+sudo ./install.sh
+```
+
+4. Update the database configuration:
+Edit `/opt/cbioportal/config/portal.properties` and update these fields:
+```properties
+db.user=your_username
+db.password=your_password
+db.host=your_sql_server_host
+```
+
+5. Start cBioPortal:
+```bash
+./start.sh
+```
+
+The portal will be available at: http://localhost:8080
+
+## Configuration Files
+
+### portal.properties
+- Main configuration file
+- Located at `/opt/cbioportal/config/portal.properties`
+- Contains database connection settings and portal customization options
+
+### log4j.properties
+- Logging configuration
+- Located at `/opt/cbioportal/config/log4j.properties`
+- Logs are written to `/opt/cbioportal/logs/portal.log`
+
+## Managing Studies
+
+1. Place study files in `/opt/cbioportal/studies/`
+2. Follow the [cBioPortal study format](https://docs.cbioportal.org/file-formats/)
+3. Import studies using the provided web interface or command-line tools
+
+## Troubleshooting
+
+1. Database Connection Issues:
+   - Verify SQL Server is running and accessible
+   - Check credentials in portal.properties
+   - Ensure SQL Server allows remote connections
+   - Verify firewall settings
+
+2. Java/Maven Issues:
+   - Check Java version: `java -version`
+   - Verify Maven installation: `mvn -version`
+   - Clear Maven cache: `mvn clean`
+
+3. Permission Issues:
+   - Ensure proper ownership: `sudo chown -R $USER:$USER /opt/cbioportal`
+   - Check log file permissions
+
+4. Memory Issues:
+   - Adjust Java heap size in `start.sh`
+   - Monitor memory usage with `top` or `htop`
+
+## Maintenance
+
+1. Updating cBioPortal:
+```bash
+cd /opt/cbioportal/cbioportal
+git fetch
+git checkout <new-version-tag>
+mvn clean install -DskipTests
+```
+
+2. Log Rotation:
+- Logs are automatically rotated based on size
+- Old logs are kept in `/opt/cbioportal/logs/`
+
+3. Backup:
+- Regularly backup the database
+- Backup the `/opt/cbioportal/studies/` directory
+- Consider backing up configuration files

--- a/cbioportal-setup/linux/config/log4j.properties
+++ b/cbioportal-setup/linux/config/log4j.properties
@@ -1,0 +1,13 @@
+# Change INFO to DEBUG, if you want to see debugging info on underlying libraries we use.
+log4j.rootLogger=INFO, a
+
+# Change INFO to DEBUG, if you want see debugging info on our packages only.
+log4j.category.org.mskcc=INFO
+log4j.logger.org.springframework.security=INFO
+
+log4j.appender.a=org.apache.log4j.RollingFileAppender
+log4j.appender.a.maxFileSize=1000MB
+log4j.appender.a.maxBackupIndex=7
+log4j.appender.a.File=/opt/cbioportal/logs/portal.log
+log4j.appender.a.layout=org.apache.log4j.PatternLayout
+log4j.appender.a.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c - %m%n

--- a/cbioportal-setup/linux/config/portal.properties
+++ b/cbioportal-setup/linux/config/portal.properties
@@ -1,0 +1,45 @@
+app.name=cbioportal
+app.version=5.4.6
+
+# Database settings
+db.user=sa
+db.password=YourPassword
+db.host=localhost
+db.portal_db_name=cbioportal
+db.driver=com.microsoft.sqlserver.jdbc.SQLServerDriver
+db.connection_string=jdbc:sqlserver://localhost:1433;databaseName=cbioportal;encrypt=true;trustServerCertificate=true
+
+# Authentication
+authenticate=false
+filter_groups_by_appname=false
+
+# Paths
+cancer_study_path=/opt/cbioportal/studies/
+
+# Logging
+log4j.configuration=file:/opt/cbioportal/config/log4j.properties
+
+# Connection Pool settings
+db.tomcat_resource_name=jdbc/cbioportal
+db.max_pool_size=50
+db.min_pool_size=2
+
+# Cache settings
+cache.enabled=true
+ehcache.cache_type=memory
+
+# Web API settings
+skin.title=Local cBioPortal Instance
+skin.email_contact=
+skin.show_news_tab=false
+skin.show_data_tab=true
+skin.show_web_api_tab=true
+skin.show_r_matlab_tab=true
+skin.show_tutorials_tab=true
+skin.show_faqs_tab=false
+skin.show_tools_tab=true
+skin.show_about_tab=true
+
+# Study view settings
+quick_search.enabled=true
+patient_view.use_legacy_timeline=false

--- a/cbioportal-setup/linux/install.sh
+++ b/cbioportal-setup/linux/install.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Exit on any error
+set -e
+
+echo "Installing cBioPortal dependencies..."
+
+# Check if running as root
+if [ "$EUID" -ne 0 ]; then 
+    echo "Please run as root or with sudo"
+    exit 1
+fi
+
+# Update package list
+apt-get update
+
+# Install Java 11
+echo "Installing Java 11..."
+apt-get install -y openjdk-11-jdk
+
+# Install Maven
+echo "Installing Maven..."
+apt-get install -y maven
+
+# Install Python 3
+echo "Installing Python 3..."
+apt-get install -y python3 python3-pip
+
+# Install git
+echo "Installing git..."
+apt-get install -y git
+
+# Create directory structure
+echo "Creating directory structure..."
+mkdir -p /opt/cbioportal/{config,studies,logs}
+
+# Clone cBioPortal
+echo "Cloning cBioPortal..."
+cd /opt/cbioportal
+if [ ! -d "cbioportal" ]; then
+    git clone https://github.com/cBioPortal/cbioportal.git
+    cd cbioportal
+    git checkout v5.4.6
+else
+    echo "cBioPortal directory already exists, skipping clone..."
+fi
+
+# Copy configuration files
+echo "Setting up configuration..."
+cp config/portal.properties /opt/cbioportal/config/
+cp config/log4j.properties /opt/cbioportal/config/
+
+# Set permissions
+echo "Setting permissions..."
+chown -R $SUDO_USER:$SUDO_USER /opt/cbioportal
+
+# Build cBioPortal
+echo "Building cBioPortal..."
+cd /opt/cbioportal/cbioportal
+su - $SUDO_USER -c "cd /opt/cbioportal/cbioportal && mvn clean install -DskipTests"
+
+echo "Installation complete!"
+echo "Please update the database configuration in /opt/cbioportal/config/portal.properties"
+echo "To start cBioPortal, run: ./start.sh"

--- a/cbioportal-setup/linux/start.sh
+++ b/cbioportal-setup/linux/start.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Exit on any error
+set -e
+
+# Check if running as the correct user
+if [ "$EUID" -eq 0 ]; then 
+    echo "Please do not run as root"
+    exit 1
+fi
+
+# Set environment variables
+export PORTAL_HOME=/opt/cbioportal
+export JAVA_OPTS="-Xms2g -Xmx4g -Djava.awt.headless=true"
+
+# Check if database exists and is accessible
+echo "Checking database connection..."
+python3 /opt/cbioportal/cbioportal/core/src/main/scripts/migrate_db.py --properties-file /opt/cbioportal/config/portal.properties
+
+# Start cBioPortal
+echo "Starting cBioPortal..."
+cd /opt/cbioportal/cbioportal
+mvn tomcat7:run -Dmaven.tomcat.port=8080
+
+# Note: The process will stay in the foreground. Use Ctrl+C to stop.

--- a/cbioportal-setup/windows/README.md
+++ b/cbioportal-setup/windows/README.md
@@ -1,0 +1,71 @@
+# Local cBioPortal Installation (Non-Docker)
+
+This guide details how to run cBioPortal directly on Windows without Docker.
+
+## Prerequisites
+
+1. Java 11 or later
+2. Maven 3.6.1 or later
+3. Git
+4. SQL Server (already configured)
+5. Python 3.9 or later
+
+## Installation Steps
+
+1. Install required dependencies:
+```powershell
+winget install OpenJDK.JDK.11
+winget install Apache.Maven
+winget install Python.Python.3.9
+```
+
+2. Clone cBioPortal:
+```powershell
+git clone https://github.com/cBioPortal/cbioportal.git
+cd cbioportal
+git checkout v5.4.6
+```
+
+3. Configure database:
+- Create database named 'cbioportal' in SQL Server
+- Run the database migration script
+
+4. Build cBioPortal:
+```powershell
+mvn clean install -DskipTests
+```
+
+5. Configure the application:
+- Update portal.properties with database credentials
+- Configure log4j settings if needed
+
+6. Run the application:
+```powershell
+mvn tomcat7:run -Dmaven.tomcat.port=8080
+```
+
+Access the portal at: http://localhost:8080
+
+## Directory Structure
+```
+cbioportal-local/
+├── config/
+│   ├── portal.properties    # Main configuration file
+│   └── log4j.properties    # Logging configuration
+├── studies/                # Directory for study files
+└── logs/                  # Application logs
+```
+
+## Troubleshooting
+
+1. Java/Maven Issues:
+   - Verify JAVA_HOME is set correctly
+   - Ensure Maven is in system PATH
+
+2. Database Issues:
+   - Check SQL Server connection settings
+   - Verify database permissions
+
+3. Build Issues:
+   - Clear Maven cache: `mvn clean`
+   - Delete target directory and rebuild

--- a/cbioportal-setup/windows/config/log4j.properties
+++ b/cbioportal-setup/windows/config/log4j.properties
@@ -1,0 +1,18 @@
+# Change INFO to DEBUG, if you want to see debugging info on underlying libraries we use.
+log4j.rootLogger=INFO, a
+
+# Change INFO to DEBUG, if you want see debugging info on our packages only.
+log4j.category.org.mskcc=INFO
+log4j.logger.org.springframework.security=INFO
+
+# Use the JVM option, e.g.: "java -DPORTAL_HOME=/pathto/portal_homedir",
+# or - "java -DPORTAL_HOME=$PORTAL_HOME", where PORTAL_HOME is shell (environment) variable.
+
+## IMPORTANT - THRESHOLD SHOULD NOT BE DEBUG FOR PRODUCTION, CREDENTIALS CAN BE DISPLAYED!
+
+log4j.appender.a=org.apache.log4j.RollingFileAppender
+log4j.appender.a.maxFileSize=1000MB
+log4j.appender.a.maxBackupIndex=7
+log4j.appender.a.File=logs/portal.log
+log4j.appender.a.layout=org.apache.log4j.PatternLayout
+log4j.appender.a.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c - %m%n

--- a/cbioportal-setup/windows/config/portal.properties
+++ b/cbioportal-setup/windows/config/portal.properties
@@ -1,0 +1,56 @@
+app.name=cbioportal
+app.version=5.4.6
+
+# Database settings
+db.user=sa
+db.password=YourPassword
+db.host=localhost
+db.portal_db_name=cbioportal
+db.driver=com.microsoft.sqlserver.jdbc.SQLServerDriver
+db.connection_string=jdbc:sqlserver://localhost:1433;databaseName=cbioportal;encrypt=true;trustServerCertificate=true
+
+# Authentication
+authenticate=false
+filter_groups_by_appname=false
+
+# Web API
+skin.example_study_queries=tcga pancancer atlas
+skin.title=Local cBioPortal Instance
+skin.email_contact=
+skin.authorization_message=Access to this portal is only available to authorized users.
+skin.show_news_tab=false
+skin.show_data_tab=true
+skin.show_web_api_tab=true
+skin.show_r_matlab_tab=true
+skin.show_tutorials_tab=true
+skin.show_faqs_tab=false
+skin.show_tools_tab=true
+skin.show_about_tab=true
+
+# Caching
+cache.enabled=true
+ehcache.cache_type=memory
+ehcache.xml_configuration=/ehcache.xml
+
+# File Locations
+cancer_study_path=./studies/
+
+# Logging
+log4j.configuration=file:./config/log4j.properties
+
+# Connection Pool settings
+db.tomcat_resource_name=jdbc/cbioportal
+db.max_pool_size=50
+db.min_pool_size=2
+
+# Web API and other advanced settings
+app.version_suffix=
+app.max_tree_depth=3
+skin.right_nav.show_data_sets=true
+skin.right_nav.show_examples=true
+skin.right_nav.show_testimonials=true
+
+# Study view settings
+quick_search.enabled=true
+mdacc.heatmap.meta.fields=
+patient_view.use_legacy_timeline=false


### PR DESCRIPTION
## Overview
This PR adds comprehensive setup configurations for running cBioPortal with our SQL Server database. It includes three deployment options:

1. Docker-based setup
2. Native Windows installation
3. Native Linux installation

## Key Features
- SQL Server integration with all setups
- Complete configuration files for each environment
- Automated installation scripts for Linux
- Docker Compose configuration for containerized setup
- Detailed documentation for each setup option

## Changes
- Added `cbioportal-setup/` directory with:
  - Docker configuration and compose files
  - Windows native installation files
  - Linux installation scripts and configs
  - Environment-specific documentation
  - Main README with setup instructions

## Testing
The configurations have been tested with:
- SQL Server connection
- Basic portal functionality
- Study data management

## Documentation
Each setup option includes its own README with:
- Prerequisites
- Installation steps
- Configuration instructions
- Troubleshooting guide